### PR TITLE
Fix pipeline creating wrong directory

### DIFF
--- a/.github/workflows/build-jar-and-native.yml
+++ b/.github/workflows/build-jar-and-native.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Package JAR
         run: |
-          mkdir -p build
+          mkdir -p dist
           jar cfm dist/Korz.jar src/META-INF/MANIFEST.MF -C out .
 
       - name: Upload JAR as Artifact


### PR DESCRIPTION
This PR fixes an issue where a directory called `build` was created instead of the directory `dist`. This interfered with the saving a jar to `dist`.